### PR TITLE
Output debuff info to console.

### DIFF
--- a/index.es
+++ b/index.es
@@ -347,6 +347,15 @@ class PoiPluginMapHp extends Component {
       )
       success(msg)
       toast(msg, { type: 'success', title: t('Map debuff') })
+
+      /*
+        Notification area sometimes scrolls too fast,
+        would be nice to have a confirmation somewhere sticky,
+        like console output.
+       */
+      /* eslint-disable no-console */
+      console.info(msg)
+      /* eslint-enable no-console */
       return
     }
 


### PR DESCRIPTION
Notification sometimes scroll too fast due to a burst of API calls right after returning to port. This would allow user to check for it in console output.

Tested manually:
![2024-08-23_22-55](https://github.com/user-attachments/assets/23d4c90c-d8db-4867-a81c-87ca19ebec49)
